### PR TITLE
Update search to ignore case

### DIFF
--- a/website/src/App.js
+++ b/website/src/App.js
@@ -103,10 +103,11 @@ class App extends Component {
   }
 
   _onSubmit(text) {
+    const lcText = text.toLowerCase()
     let matches = [];
     _.forEach(IconFamilies, (icons, family) => {
       let names = Object.keys(icons);
-      let results = names.filter(name => name.indexOf(text) >= 0);
+      let results = names.filter(name => name.toLowerCase().indexOf(lcText) >= 0);
       if (results.length) {
         matches = [...matches, { family, names: results }];
       }


### PR DESCRIPTION
When I was searching, I kept using uppercase for the first letter. E.g. searching for 'Home'. Which wouldn't match anything and I'd get super confused!

So lets lowercase everything to help out buffoon's like me.