### PR TITLE
remove Font.style from createIconSetFromFontello

### DIFF
--- a/createIconSetFromFontello.js
+++ b/createIconSetFromFontello.js
@@ -1,6 +1,5 @@
-import { Font } from 'expo';
 import createIconSetFromFontello from './vendor/react-native-vector-icons/lib/create-icon-set-from-fontello';
 
 export default function(config, expoFontName, expoAssetId) {
-  return createIconSetFromFontello(config, Font.style(expoFontName).fontFamily, expoAssetId);
+  return createIconSetFromFontello(config, expoFontName, expoAssetId);
 }


### PR DESCRIPTION
Not needed anymore. Since Expo 24, the function throws an error.