### PR TITLE
Fix depreciate Font.style (Expo SDK >= 24)

### DIFF
--- a/createIconSetFromIcoMoon.js
+++ b/createIconSetFromIcoMoon.js
@@ -1,6 +1,5 @@
-import { Font } from 'expo';
 import createIconSetFromIcoMoon from './vendor/react-native-vector-icons/lib/create-icon-set-from-icomoon';
 
 export default function(config, expoFontName, expoAssetId) {
-  return createIconSetFromIcoMoon(config, expoFontName, expoAssetId);
+    return createIconSetFromIcoMoon(config, expoFontName , expoAssetId);
 }


### PR DESCRIPTION
Remove Font.style to createIconSetFromIcoMoon because it's useless and depreciate since Expo SDK >= 24 