### PR TITLE
update icons package to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://expo.github.io/vector-icons",
   "dependencies": {
     "lodash": "^4.17.4",
-    "react-native-vector-icons": "4.5.0"
+    "react-native-vector-icons": "4.6.0"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://expo.github.io/vector-icons",
   "dependencies": {
     "lodash": "^4.17.4",
-    "react-native-vector-icons": "4.6.0"
+    "react-native-vector-icons": "4.6.0",
     "expo-font": "^1.0.0"
   },
   "devDependencies": {}


### PR DESCRIPTION
I've simply bumped the version here to the latest to expose some of the more recent material community icons. If these could be included in the next sdk release, that would be great!