### PR TITLE
[don't merge yet] Update "expo-font" imports

### DIFF
--- a/createIconSet.js
+++ b/createIconSet.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text } from 'react-native';
-import { Font } from 'expo-font';
+import * as Font from 'expo-font';
 import createIconSet from './vendor/react-native-vector-icons/lib/create-icon-set';
 import createIconButtonComponent from './vendor/react-native-vector-icons/lib/icon-button';
 

--- a/createIconSetFromIcoMoon.js
+++ b/createIconSetFromIcoMoon.js
@@ -1,4 +1,3 @@
-import { Font } from 'expo-font';
 import createIconSetFromIcoMoon from './vendor/react-native-vector-icons/lib/create-icon-set-from-icomoon';
 
 export default function(config, expoFontName, expoAssetId) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-native-vector-icons": "6.0.0"
   },
   "peerDependencies": {
-    "expo-font": "^1.0.0"
+    "expo-font": "^2.0.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Instead of `import { Font } from 'expo-font'` we now have `import * as Font from 'expo-font'`. (In the cases where you use only a few named exports, this opens the path to dead-export elimination in some bundlers.)

Test plan: made this change locally in my node_modules and loaded in NCL in the Expo repo

**Don't merge this yet** since expo-font 2.0.0 has not been published to npm. Just putting this PR up so we're ready to go.