### PR TITLE
fix: scroll view height

### DIFF
--- a/website/src/IconList.js
+++ b/website/src/IconList.js
@@ -7,7 +7,7 @@ export default class IconList extends React.Component {
       <AutoSizer>
         {({ height, width }) => (
           <List
-            height={height}
+            height={height - 120} // The last element was not visible 120px = header + search bar height
             width={width}
             rowCount={this.props.data.length}
             rowHeight={60}


### PR DESCRIPTION
The last 2 icons were not visible because the `AutoSizer` element was not deducing the height of header and the search bar.

Fixed the issue by subtracting the outer height of the Header-Container and the Searchbar-container

![snap](https://user-images.githubusercontent.com/17236768/49793811-07886d00-fd5c-11e8-8ed2-edc62ae092e8.PNG)

