### PR TITLE
Include string as a valid type for GlyphMap entries.

### DIFF
--- a/build/createIconSet.d.ts
+++ b/build/createIconSet.d.ts
@@ -60,7 +60,7 @@ export interface IconButtonProps<GLYPHS extends string> extends IconProps<GLYPHS
     backgroundColor?: string | OpaqueColorValue;
 }
 export declare type GlyphMap<G extends string> = {
-    [K in G]: number;
+    [K in G]: number | string;
 };
 export interface Icon<G extends string, FN extends string> {
     defaultProps: any;

--- a/src/createIconSet.tsx
+++ b/src/createIconSet.tsx
@@ -76,7 +76,7 @@ export interface IconButtonProps<GLYPHS extends string> extends IconProps<GLYPHS
   backgroundColor?: string | OpaqueColorValue;
 }
 
-export type GlyphMap<G extends string> = { [K in G]: number }
+export type GlyphMap<G extends string> = { [K in G]: number | string }
 
 export interface Icon<G extends string, FN extends string> {
   defaultProps: any;


### PR DESCRIPTION
I recently upgraded to Expo SDK v40 (and therefore my version of `@expo/vector-icons` upgraded along with it) and I started getting type errors on a usage of `createIconSet` because my glyph map was using strings instead of numbers.

Since my icon set still works, and the [docs](https://docs.expo.io/guides/icons/#createiconset) say:

> Returns your own custom font based on the glyphMap where the key is the icon name and the value is either a **UTF-8 character** or it's character code.

I think this was caused by a simple oversight when the typings were added in.

This pull request changes the type from `number` to `number | string`.