### PR TITLE
Disabled user select on the Icon detail screen

### DIFF
--- a/website/screens/Detail.js
+++ b/website/screens/Detail.js
@@ -121,6 +121,7 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 24,
     fontWeight: '600',
+    userSelect: "none"
   },
   button: {
     alignSelf: 'center',

--- a/website/screens/Detail.js
+++ b/website/screens/Detail.js
@@ -121,7 +121,7 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 24,
     fontWeight: '600',
-    userSelect: "none"
+    userSelect: 'none',
   },
   button: {
     alignSelf: 'center',


### PR DESCRIPTION
Once I find an icon, I often just copy the code as one block and then delete the '2. Render the component' in my editor. I find that it's easier to copy the whole thing once before tabbing back to the editor rather than jumping back and forth, once for the import and again for the icon.

![Screen Shot 2022-02-14 at 6 41 20 PM](https://user-images.githubusercontent.com/10982992/153965507-dd059792-0ff1-43b6-bb68-4e29ef2283a5.png)

![Screen Shot 2022-02-14 at 6 42 27 PM](https://user-images.githubusercontent.com/10982992/153965538-c375f334-59d1-4856-be2d-f772efa122d5.png)

