### PR TITLE
Update readme import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This library is part of the `expo` package, so if you are using `expo` you can s
 
 ```tsx
 import React from 'react';
-import { Ionicons } from '@expo/vector-icons/Ionicons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 
 export default class IconExample extends React.Component {
   render() {


### PR DESCRIPTION
When a developer imports an icon set from vector-icons, their app will load all the icons sets and also include them as assets in any published updates. This happens because this package exports all icons in one file, and when writing an import like `import { Feather } from '@expo/vector-icons'`, all the other icon sets will be required, even though they are not used. They are loaded because Metro bundler does not support tree shaking/removing unused assets.

So, this PR bypasses that behavior by suggesting directly importing the icon set directly. 