### PR TITLE
Don't let user select copy when copying entire page

### DIFF
--- a/website/components/CopyButton.js
+++ b/website/components/CopyButton.js
@@ -23,6 +23,7 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     color: '#fff',
     backgroundColor: '#06bcee',
+    userSelect: 'none'
   },
 });
 


### PR DESCRIPTION
Make it so that it doesnt select the "COPY" button text when you copy the whole page

<img width="744" alt="Screenshot 2024-05-09 at 12 02 27 PM" src="https://github.com/expo/vector-icons/assets/10982992/be861502-b3af-4461-b1d0-5c1c030f9306">

import AntDesign from '@expo/vector-icons/AntDesign';
COPY
<AntDesign name="stepforward" size={24} color="black" />
