### PR TITLE
fix: fix copy old import

### DIFF
--- a/website/screens/Detail.js
+++ b/website/screens/Detail.js
@@ -21,7 +21,7 @@ const Detail = ({ route, navigation }) => {
   let isDesktop = useMediaQuery({ query: '(min-width: 900px)' });
 
   const handleCopyImport = () => {
-    Clipboard.setString(`import { ${family} } from '@expo/vector-icons';`);
+    Clipboard.setString(`import ${family} from '@expo/vector-icons/${family}';`);
     setCopyColorImp(true);
     setCopyColorRen(false);
   };


### PR DESCRIPTION
Fixes where component import is like this in the UI
`import AntDesign from '@expo/vector-icons/AntDesign';`

but clicking "Copy" buttons copies this text
`import { AntDesign } from '@expo/vector-icons';`