### PR TITLE
fix: fix warning lint

### DIFF
--- a/src/AntDesign.ts
+++ b/src/AntDesign.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import createIconSet from './createIconSet';
 import font from './vendor/react-native-vector-icons/Fonts/AntDesign.ttf';

--- a/src/Entypo.ts
+++ b/src/Entypo.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import createIconSet from './createIconSet';
 import font from './vendor/react-native-vector-icons/Fonts/Entypo.ttf';

--- a/src/EvilIcons.ts
+++ b/src/EvilIcons.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import createIconSet from './createIconSet';
 import font from './vendor/react-native-vector-icons/Fonts/EvilIcons.ttf';

--- a/src/Feather.ts
+++ b/src/Feather.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import createIconSet from './createIconSet';
 import font from './vendor/react-native-vector-icons/Fonts/Feather.ttf';

--- a/src/FontAwesome.ts
+++ b/src/FontAwesome.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import createIconSet from './createIconSet';
 import font from './vendor/react-native-vector-icons/Fonts/FontAwesome.ttf';

--- a/src/FontAwesome5.ts
+++ b/src/FontAwesome5.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import { createFA5iconSet } from './createIconSetFromFontAwesome5';
 import glyphMap from './vendor/react-native-vector-icons/glyphmaps/FontAwesome5Free.json';

--- a/src/FontAwesome6.ts
+++ b/src/FontAwesome6.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import { createFA6iconSet } from './createIconSetFromFontAwesome6';
 import glyphMap from './vendor/react-native-vector-icons/glyphmaps/FontAwesome6Free.json';

--- a/src/Fontisto.ts
+++ b/src/Fontisto.ts
@@ -2,7 +2,7 @@
  * Feather icon set component.
  * Usage: <Feather name="icon-name" size={20} color="#4F8EF7" />
  */
-"use client";
+'use client';
 
 import createIconSet from './createIconSet';
 import font from './vendor/react-native-vector-icons/Fonts/Fontisto.ttf';

--- a/src/Foundation.ts
+++ b/src/Foundation.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import createIconSet from './createIconSet';
 import font from './vendor/react-native-vector-icons/Fonts/Foundation.ttf';

--- a/src/Icons.ts
+++ b/src/Icons.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 export { default as AntDesign } from './AntDesign';
 export { default as Entypo } from './Entypo';

--- a/src/Ionicons.ts
+++ b/src/Ionicons.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import createIconSet from './createIconSet';
 import font from './vendor/react-native-vector-icons/Fonts/Ionicons.ttf';

--- a/src/MaterialCommunityIcons.ts
+++ b/src/MaterialCommunityIcons.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import createIconSet from './createIconSet';
 import font from './vendor/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf';

--- a/src/MaterialIcons.ts
+++ b/src/MaterialIcons.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import createIconSet from './createIconSet';
 import font from './vendor/react-native-vector-icons/Fonts/MaterialIcons.ttf';

--- a/src/Octicons.ts
+++ b/src/Octicons.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import createIconSet from './createIconSet';
 import font from './vendor/react-native-vector-icons/Fonts/Octicons.ttf';

--- a/src/SimpleLineIcons.ts
+++ b/src/SimpleLineIcons.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import createIconSet from './createIconSet';
 import font from './vendor/react-native-vector-icons/Fonts/SimpleLineIcons.ttf';

--- a/src/Zocial.ts
+++ b/src/Zocial.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import createIconSet from './createIconSet';
 import font from './vendor/react-native-vector-icons/Fonts/Zocial.ttf';


### PR DESCRIPTION

* Corrections required by lint to maintain the code standard, i just replace "use client" to 'use client'.
* replace " " to ' '

/vector-icons/src/AntDesign.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/Entypo.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/EvilIcons.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/Feather.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/FontAwesome.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/FontAwesome5.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/FontAwesome6.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/Fontisto.ts 5:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/Foundation.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/Icons.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/Ionicons.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/MaterialCommunityIcons.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/MaterialIcons.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/Octicons.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier /vector-icons/src/SimpleLineIcons.ts 1:1 warning Replace "use·client" with 'use·client' prettier/prettier
/vector-icons/src/Zocial.ts 1:1 warning Replace "use·client" with 'use·client'
