### PR TITLE
chore: Drop `prop-types` and add missing peer dependencies

### DIFF
--- a/build/vendor/react-native-vector-icons/lib/create-multi-style-icon-set.js
+++ b/build/vendor/react-native-vector-icons/lib/create-multi-style-icon-set.js
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 
 import createIconSet, {
   DEFAULT_ICON_COLOR,
@@ -114,10 +113,7 @@ export default function createMultiStyleIconSet(styles, optionsInput = {}) {
 
   function createStyledIconClass(selectClass = '') {
     class IconClass extends PureComponent {
-      static propTypes = styleNames.reduce((acc, name) => {
-        acc[name] = PropTypes.bool;
-        return acc;
-      }, {});
+      // NOTE(@expo/vector-icons): Modified to remove propTypes
 
       static defaultProps = styleNames.reduce((acc, name) => {
         acc[name] = false;

--- a/build/vendor/react-native-vector-icons/lib/icon-button.js
+++ b/build/vendor/react-native-vector-icons/lib/icon-button.js
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import { StyleSheet, Text, TouchableHighlight, View } from 'react-native';
 import { pick, omit } from './object-utils';
 
@@ -67,18 +66,7 @@ const TOUCHABLE_PROP_NAMES = [
 
 export default function createIconButtonComponent(Icon) {
   return class IconButton extends PureComponent {
-    static propTypes = {
-      backgroundColor: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number,
-      ]),
-      borderRadius: PropTypes.number,
-      color: PropTypes.any, // eslint-disable-line react/forbid-prop-types
-      size: PropTypes.number,
-      iconStyle: PropTypes.any, // eslint-disable-line react/forbid-prop-types
-      style: PropTypes.any, // eslint-disable-line react/forbid-prop-types
-      children: PropTypes.node,
-    };
+    // NOTE(@expo/vector-icons): Modified to remove propTypes
 
     static defaultProps = {
       backgroundColor: IOS7_BLUE,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "module": "build/Icons.js",
   "types": "build/Icons.d.ts",
   "scripts": {
-    "copy-vendor": "cp -R src/vendor/ build/vendor/",
+    "copy-vendor": "rm -rf build/vendor && cp -R src/vendor build/vendor",
     "generate-lazy": "expo-module babel --config-file ./babel.config.build.js --source-maps --out-file build/IconsLazy.js build/Icons.js",
     "build": "EXPO_NONINTERACTIVE=1 expo-module build && npm run generate-lazy && npm run copy-vendor",
     "build:dev": "expo-module build",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {},
   "peerDependencies": {
     "expo-font": "*",
-    "react": ">= 15.7.0",
+    "react": "*",
     "react-native": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,5 @@
     "expo-module-scripts": "^3.4.0",
     "prettier": "^3.1.1"
   },
-  "dependencies": {
-    "prop-types": "^15.8.1"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -46,5 +46,10 @@
     "expo-module-scripts": "^3.4.0",
     "prettier": "^3.1.1"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "peerDependencies": {
+    "expo-font": "*",
+    "react": ">= 15.7.0",
+    "react-native": "*"
+  }
 }

--- a/src/vendor/react-native-vector-icons/lib/create-multi-style-icon-set.js
+++ b/src/vendor/react-native-vector-icons/lib/create-multi-style-icon-set.js
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 
 import createIconSet, {
   DEFAULT_ICON_COLOR,
@@ -114,10 +113,7 @@ export default function createMultiStyleIconSet(styles, optionsInput = {}) {
 
   function createStyledIconClass(selectClass = '') {
     class IconClass extends PureComponent {
-      static propTypes = styleNames.reduce((acc, name) => {
-        acc[name] = PropTypes.bool;
-        return acc;
-      }, {});
+      // NOTE(@expo/vector-icons): Modified to remove propTypes
 
       static defaultProps = styleNames.reduce((acc, name) => {
         acc[name] = false;

--- a/src/vendor/react-native-vector-icons/lib/icon-button.js
+++ b/src/vendor/react-native-vector-icons/lib/icon-button.js
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import { StyleSheet, Text, TouchableHighlight, View } from 'react-native';
 import { pick, omit } from './object-utils';
 
@@ -67,18 +66,7 @@ const TOUCHABLE_PROP_NAMES = [
 
 export default function createIconButtonComponent(Icon) {
   return class IconButton extends PureComponent {
-    static propTypes = {
-      backgroundColor: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number,
-      ]),
-      borderRadius: PropTypes.number,
-      color: PropTypes.any, // eslint-disable-line react/forbid-prop-types
-      size: PropTypes.number,
-      iconStyle: PropTypes.any, // eslint-disable-line react/forbid-prop-types
-      style: PropTypes.any, // eslint-disable-line react/forbid-prop-types
-      children: PropTypes.node,
-    };
+    // NOTE(@expo/vector-icons): Modified to remove propTypes
 
     static defaultProps = {
       backgroundColor: IOS7_BLUE,


### PR DESCRIPTION
`prop-types` is quite out-of-date, and since the vendored files haven't changed in a long time, we can simply drop it.

I've also noticed that the `package.json:peerDependencies` were missing, but we're obviously still depending on `react`, `react-native`, and `expo-fonts`.

This isn't such a big problem for `react` and `react-native` since a requirement is that they must be installed directly by other peer dependencies we've got. However, `expo-font` is problematic, since there's no enforcement that that's installed directly in conjunction with `@expo/vector-icons`.

Since `expo-font` contains a native module, we can expect it to be installed directly and should specify a peer dependency rather than a regular or optional dependency.