### PR TITLE
feat: improve IconList layout with responsive columns

### DIFF
--- a/website/components/ListItem.js
+++ b/website/components/ListItem.js
@@ -5,7 +5,7 @@ import PressableOpacity from "./PressableOpacity";
 
 const ListItem = ({ name, family, onPress }) => {
   return (
-    <PressableOpacity onPress={onPress}>
+    <PressableOpacity onPress={onPress} style={{ flex: 1 }}>
       <View style={styles.container}>
         <View style={{ width: 50, justifyContent: 'center', alignItems: 'center' }}>
           <Icon family={family} name={name} size={30} />
@@ -26,7 +26,8 @@ const styles = StyleSheet.create({
     paddingVertical: 15,
     alignItems: "center",
     borderBottomWidth: 1,
-    borderBottomColor: "#e3e3e3",
+    borderRightWidth: 1,
+    borderColor: "#e3e3e3",
   },
   textView: {
     flexDirection: "column",

--- a/website/screens/List.js
+++ b/website/screens/List.js
@@ -5,7 +5,13 @@ import React, {
   useImperativeHandle,
   forwardRef,
 } from "react";
-import { StyleSheet, View, FlatList, TextInput } from "react-native";
+import {
+  StyleSheet,
+  View,
+  FlatList,
+  TextInput,
+  useWindowDimensions
+} from "react-native";
 import { useDebouncedCallback } from "use-debounce";
 import { IconsArray } from "../IconConstants";
 import ListItem from "../components/ListItem";
@@ -193,18 +199,31 @@ const IconList = React.memo(({ query, filters, navigation }) => {
     [navigation]
   );
 
+  const { width } = useWindowDimensions();
+
+  const numColumns = React.useMemo(() => {
+    return getNumColumns(width);
+  }, [width]);
+
   return (
     <FlatList
       style={{ flex: 1 }}
       data={icons}
       renderItem={renderItem}
       keyExtractor={keyExtractor}
+      numColumns={numColumns}
+      key={numColumns}
     />
   );
 });
 
 function keyExtractor(item) {
   return `${item.family}-${item.name}`;
+}
+
+function getNumColumns(width, columnWidth = 300) {
+  const numColumns = Math.floor(width / columnWidth);
+  return Math.max(numColumns, 1);
 }
 
 const IconRow = React.memo(({ item, navigation }) => {


### PR DESCRIPTION
## Why
The icon list provides a way for users to navigate through supported icons. It currently supports only one column (implemented with a FlatList). On desktop, we can improve browsing experience by adding support for multiple column layout (grid-like), ensuring ample spacing between the items so they don't feel cramped together.

## How
- [x] Adjust the number of columns based on the window's width using `useWindowDimensions` hook.
- [x] The FlatList key must be changed when numColumns is changed for the list to be rerendered, this doesn't cause any visual fluctuations.
- [ ] However, due to the key change, there could be room for scroll preservation, please let me know if this is required and I'll look into it.