### PR TITLE
fix: align getImageSource with community package

### DIFF
--- a/src/createIconSet.tsx
+++ b/src/createIconSet.tsx
@@ -96,7 +96,7 @@ export interface Icon<G extends string, FN extends string> {
   glyphMap: GlyphMap<G>;
   getRawGlyphMap: () => GlyphMap<G>;
   getFontFamily: () => FN;
-  getImageSource: (name: G, size: number, color: ColorValue) => Promise<string | null>;
+  getImageSource: (name: G, size: number, color: ColorValue) => Promise<{ uri: string } | null>;
   loadFont: () => Promise<void>;
   font: { [x: string]: any };
   new (props: IconProps<G>): React.Component<IconProps<G>>;
@@ -129,11 +129,15 @@ export default function <G extends string, FN extends string>(
         return null;
       }
       await Font.loadAsync(font);
-      return Font.renderToImageAsync(String.fromCodePoint(glyphMap[name] as number), {
-        fontFamily: fontName,
-        color: color as string,
-        size,
-      });
+      const imagePath = await Font.renderToImageAsync(
+        String.fromCodePoint(glyphMap[name] as number),
+        {
+          fontFamily: fontName,
+          color: color as string,
+          size,
+        }
+      );
+      return { uri: imagePath };
     };
 
     _mounted = false;


### PR DESCRIPTION
We should return the same shape of data as in https://github.com/oblador/react-native-vector-icons/blob/d1828468880af3b8289c3017cb4213fbad7ba977/packages/common/src/create-icon-set.tsx#L211