### PR TITLE
chore: specify expo-font peer dep for getImageSource

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "expo-font": "*",
+    "expo-font": ">=13.2.0",
     "react": "*",
     "react-native": "*"
   }


### PR DESCRIPTION
as per the title: `getImageSource` implementation requires expo-font at least `v13.2.0`