### PR TITLE
ci: clear node token to use OIDC for npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,6 @@ jobs:
       - run: yarn install --frozen-lockfile
         if: ${{ steps.release.outputs.release_created || github.event_name == 'workflow_dispatch' }}
       - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: '' # Clear the secret, if provided, so npm publishes via OIDC
         if: ${{ steps.release.outputs.release_created || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
somehow, from somewhere, an `NODE_AUTH_TOKEN` is "polluting" the environment. npm picks it up and that seems to fail the publish process